### PR TITLE
Signal Output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -133,6 +133,8 @@ func (a *MethodAzure) InitRootCommand() {
 			return nil
 		},
 	}
+
+	a.RootCmd.AddCommand(a.VersionCmd)
 }
 
 // A utility function to validate that the provided output format is one of the supported formats: json, yaml, signal.


### PR DESCRIPTION
* Adds `PersistentPostRunE` to write the signal out
* Adds missing line to attach the version command to the root command