### PR TITLE
nil handling when creating vnet and subnet lookups

### DIFF
--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -82,9 +82,15 @@ func EnumerateVMs(ctx context.Context, cfg config.AzureConfig) (*AzureResourceRe
 	vnetLookup := make(map[string]string)
 	subnetLookup := make(map[string]string)
 	for _, v := range vnetReport.Resources.VirtualNetworks {
-		vnetLookup[v.VNetName] = *v.Details.ID
-		for _, s := range v.Details.Properties.Subnets {
-			subnetLookup[*s.ID] = *s.Properties.AddressPrefix
+		if v.Details.ID != nil {
+			vnetLookup[v.VNetName] = *v.Details.ID
+			if v.Details.Properties != nil && v.Details.Properties.Subnets != nil {
+				for _, s := range v.Details.Properties.Subnets {
+					if s.ID != nil && s.Properties != nil && s.Properties.AddressPrefix != nil {
+						subnetLookup[*s.ID] = *s.Properties.AddressPrefix
+					}
+				}
+			}
 		}
 	}
 

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -82,15 +82,18 @@ func EnumerateVMs(ctx context.Context, cfg config.AzureConfig) (*AzureResourceRe
 	vnetLookup := make(map[string]string)
 	subnetLookup := make(map[string]string)
 	for _, v := range vnetReport.Resources.VirtualNetworks {
-		if v.Details.ID != nil {
-			vnetLookup[v.VNetName] = *v.Details.ID
-			if v.Details.Properties != nil && v.Details.Properties.Subnets != nil {
-				for _, s := range v.Details.Properties.Subnets {
-					if s.ID != nil && s.Properties != nil && s.Properties.AddressPrefix != nil {
-						subnetLookup[*s.ID] = *s.Properties.AddressPrefix
-					}
-				}
+		if v.Details.ID == nil {
+			continue
+		}
+		vnetLookup[v.VNetName] = *v.Details.ID
+		if v.Details.Properties != nil && v.Details.Properties.Subnets != nil {
+			continue
+		}
+		for _, s := range v.Details.Properties.Subnets {
+			if s.ID != nil && s.Properties != nil && s.Properties.AddressPrefix != nil {
+				continue
 			}
+			subnetLookup[*s.ID] = *s.Properties.AddressPrefix
 		}
 	}
 


### PR DESCRIPTION
Hit a nil pointer when accessing subnet properties field; handles this before creating lookups